### PR TITLE
Update patch for v6.2.0 to allow compilation with gcc 13+

### DIFF
--- a/printf.patch
+++ b/printf.patch
@@ -57,3 +57,31 @@ index 48cbade..d5f3d9a 100644
  #ifndef PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_SOFT
  #define PRINTF_ALIAS_STANDARD_FUNCTION_NAMES_SOFT 0
  #endif
+diff --git a/src/printf/printf.c b/src/printf/printf.c
+index a2c7405..7300ff7 100644
+--- a/src/printf/printf.c
++++ b/src/printf/printf.c
+@@ -654,11 +654,6 @@ struct scaling_factor {
+ };
+
+ static floating_point_t apply_scaling(floating_point_t num, struct scaling_factor normalization)
+-{
+-  return normalization.multiply ? num * normalization.raw_factor : num / normalization.raw_factor;
+-}
+-
+-static floating_point_t unapply_scaling(floating_point_t normalized, struct scaling_factor normalization)
+ {
+ #ifdef __GNUC__
+ // accounting for a static analysis bug in GCC 6.x and earlier
+@@ -669,6 +664,11 @@ static floating_point_t unapply_scaling(floating_point_t normalized, struct scal
+ #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+ #endif
+ #endif
++  return normalization.multiply ? num * normalization.raw_factor : num / normalization.raw_factor;
++}
++
++static floating_point_t unapply_scaling(floating_point_t normalized, struct scaling_factor normalization)
++{
+   return normalization.multiply ? normalized / normalization.raw_factor : normalized * normalization.raw_factor;
+ #ifdef __GNUC__
+ #pragma GCC diagnostic pop


### PR DESCRIPTION
Fix false-positive compiler warning for an uninitialized variable with gcc 13+ on Linux:
```
In function ‘apply_scaling’,
    inlined from ‘get_normalized_components’ at modm/ext/printf/printf.c:706:29,
    inlined from ‘print_exponential_number’ at modm/ext/printf/printf.c:964:5:
modm/ext/printf/printf.c:658:66: error: ‘normalization.raw_factor’ may be used uninitialized [-Werror=maybe-uninitialized]
  658 |   return normalization.multiply ? num * normalization.raw_factor : num / normalization.raw_factor;
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
modm/ext/printf/printf.c: In function ‘print_exponential_number’:
modm/ext/printf/printf.c:904:25: note: ‘normalization.raw_factor’ was declared here
  904 |   struct scaling_factor normalization;
      |                         ^~~~~~~~~~~~~
cc1: some warnings being treated as errors
```
The workaround was already there and is extended to also cover another line of code.